### PR TITLE
Paper toggle button with thick track

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -83,7 +83,7 @@
     <br>
   
     <div center horizontal layout>
-      <div flex>Fun mode</div>
+      <div flex>Custom Colors</div>
       <paper-toggle-button class="fun"></paper-toggle-button>
     </div>
     

--- a/demo.html
+++ b/demo.html
@@ -87,6 +87,14 @@
       <paper-toggle-button class="fun"></paper-toggle-button>
     </div>
     
+    <br>
+    <br>
+    
+    <div center horizontal layout>
+      <div flex>Disabled</div>
+      <paper-toggle-button disabled></paper-toggle-button>
+    </div>
+    
   </section>
   
 </body>

--- a/demo.html
+++ b/demo.html
@@ -39,11 +39,11 @@
       width: 200px;
     }
     
-    paper-toggle-button.blue::shadow paper-radio-button::shadow #ink[checked] {
+    paper-toggle-button.blue::shadow #ink[checked] {
       color: #4285f4;
     }
     
-    paper-toggle-button.blue::shadow paper-radio-button::shadow #onRadio {
+    paper-toggle-button.blue::shadow #toggleButton[checked] {
       background-color: #4285f4;
     }
     

--- a/demo.html
+++ b/demo.html
@@ -38,17 +38,25 @@
     section {
       width: 200px;
     }
-    
-    paper-toggle-button.blue::shadow #ink[checked] {
+
+    paper-toggle-button.bluetooth::shadow [checked] .toggle-ink {
       color: #4285f4;
     }
-    
-    paper-toggle-button.blue::shadow #toggleButton[checked] {
+
+    paper-toggle-button.bluetooth::shadow [checked] .toggle {
       background-color: #4285f4;
     }
     
-    paper-toggle-button.blue::shadow #toggleBar[checked] {
-      background-color: #4285f4;
+    paper-toggle-button.fun::shadow .toggle-ink {
+      color: #009688;
+    }
+
+    paper-toggle-button.fun::shadow .toggle-bar {
+      background-color: #5677fc;
+    }
+
+    paper-toggle-button.fun::shadow .toggle-button {
+      background-color: #9c27b0;
     }
     
   </style>
@@ -68,7 +76,15 @@
     
     <div center horizontal layout>
       <div flex>Bluetooth</div>
-      <paper-toggle-button class="blue"></paper-toggle-button>
+      <paper-toggle-button class="bluetooth"></paper-toggle-button>
+    </div>
+    
+    <br>
+    <br>
+  
+    <div center horizontal layout>
+      <div flex>Fun mode</div>
+      <paper-toggle-button class="fun"></paper-toggle-button>
     </div>
     
   </section>

--- a/paper-toggle-button.css
+++ b/paper-toggle-button.css
@@ -15,6 +15,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   outline: none;
 }
 
+/* Class selectors can be overridden by users. */
+
+.toggle-bar {
+  background-color: #5a5a5a;
+}
+
+.toggle-button {
+  background-color: #f1f1f1;
+}
+
+[checked] .toggle {
+  background-color: #0f9d58;
+}
+
+.toggle-ink {
+  color: #5a5a5a;
+}
+
+[checked] .toggle-ink {
+  color: #0f9d58;
+}
+
+/* ID selectors should not be overriden by users. */
+
 #toggleContainer {
   position: relative;
   width: 32px;
@@ -25,15 +49,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   position: absolute;
   height: 100%;
   width: 100%;
-  background-color: #5a5a5a;
   border-radius: 8px;
   pointer-events: none;
-  opacity: 0.5;
+  opacity: 0.4;
   transition: background-color linear .08s;
-}
-
-#toggleBar[checked] {
-  background-color: #0f9d58;
 }
 
 #toggleButton {
@@ -42,12 +61,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   left: -2px;
   height: 20px;
   width: 20px;
-  background-color: #f1f1f1;
   border-radius: 50%;
   box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.24);
-  transition: -webkit-transform linear .08s;
-  transition: transform linear .08s;
-  transition: background-color linear .08s;
+  transition: -webkit-transform linear .08s, background-color linear .08s;
+  transition: transform linear .08s, background-color linear .08s;
 }
 
 #toggleButton.dragging {
@@ -55,10 +72,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   transition: none;
 }
 
-#toggleButton[checked] {
+[checked] #toggleButton {
   -webkit-transform: translate(16px, 0);
   transform: translate(16px, 0);
-  background-color: #0f9d58;
 }
 
 #ink {
@@ -67,9 +83,4 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   left: -14px;
   width: 48px;
   height: 48px;
-  color: #5a5a5a;
-}
-
-#ink[checked] {
-  color: #0f9d58;
 }

--- a/paper-toggle-button.css
+++ b/paper-toggle-button.css
@@ -30,7 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 .toggle-ink {
-  color: #5a5a5a;
+  color: #bbb;
 }
 
 [checked] .toggle-ink {

--- a/paper-toggle-button.css
+++ b/paper-toggle-button.css
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 /* Class selectors can be overridden by users. */
 
 .toggle-bar {
-  background-color: #5a5a5a;
+  background-color: #000000;
 }
 
 .toggle-button {
@@ -41,8 +41,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 #toggleContainer {
   position: relative;
-  width: 32px;
-  height: 16px;
+  width: 36px;
+  height: 14px;
 }
 
 #toggleContainer[disabled] {
@@ -56,18 +56,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   width: 100%;
   border-radius: 8px;
   pointer-events: none;
-  opacity: 0.4;
+  opacity: 0.26;
   transition: background-color linear .08s;
+}
+
+[checked] #toggleBar {
+  opacity: 0.5;
 }
 
 #toggleButton {
   position: absolute;
-  top: -2px;
-  left: -2px;
+  top: -3px;
   height: 20px;
   width: 20px;
   border-radius: 50%;
-  box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.24);
+  box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.4);
   transition: -webkit-transform linear .08s, background-color linear .08s;
   transition: transform linear .08s, background-color linear .08s;
 }

--- a/paper-toggle-button.css
+++ b/paper-toggle-button.css
@@ -91,4 +91,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   left: -14px;
   width: 48px;
   height: 48px;
+  pointer-events: none;
 }

--- a/paper-toggle-button.css
+++ b/paper-toggle-button.css
@@ -17,45 +17,59 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 #toggleContainer {
   position: relative;
-  width: 64px;
+  width: 32px;
   height: 16px;
 }
 
 #toggleBar {
   position: absolute;
-  top: 8px;
-  left: 16px;
-  height: 1px;
-  width: 32px;
+  height: 100%;
+  width: 100%;
   background-color: #5a5a5a;
+  border-radius: 8px;
   pointer-events: none;
+  opacity: 0.5;
+  transition: background-color linear .08s;
 }
 
 #toggleBar[checked] {
   background-color: #0f9d58;
 }
 
-#toggleContainer[checked] #checkedBar {
-  width: 100%;
-}
-
-#toggleRadio {
+#toggleButton {
   position: absolute;
-  left: 0;
-  padding: 8px 48px 8px 0;
-  margin: -8px -48px -8px 0;
+  top: -2px;
+  left: -2px;
+  height: 20px;
+  width: 20px;
+  background-color: #f1f1f1;
+  border-radius: 50%;
+  box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.24);
   transition: -webkit-transform linear .08s;
   transition: transform linear .08s;
+  transition: background-color linear .08s;
 }
 
-#toggleRadio[checked] {
-  -webkit-transform: translate(48px, 0);
-  transform: translate(48px, 0);
-  padding: 8px 0 8px 48px;
-  margin: -8px 0 -8px -48px;
-}
-
-#toggleRadio.dragging {
+#toggleButton.dragging {
   -webkit-transition: none;
   transition: none;
+}
+
+#toggleButton[checked] {
+  -webkit-transform: translate(16px, 0);
+  transform: translate(16px, 0);
+  background-color: #0f9d58;
+}
+
+#ink {
+  position: absolute;
+  top: -14px;
+  left: -14px;
+  width: 48px;
+  height: 48px;
+  color: #5a5a5a;
+}
+
+#ink[checked] {
+  color: #0f9d58;
 }

--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -71,7 +71,7 @@ To change the toggle bar and toggle button colors separately:
     <div id="toggleBar" class="toggle toggle-bar"></div>
 
     <div id="toggleButton" class="toggle toggle-button">
-      <paper-ripple id="ink" class="toggle-ink circle recenteringTouch"></paper-ripple>
+      <paper-ripple id="ink" class="toggle-ink circle"></paper-ripple>
     </div>
 
   </div>
@@ -113,10 +113,24 @@ To change the toggle bar and toggle button colors separately:
     disabled: false,
 
     eventDelegates: {
+      down: 'downAction',
+      up: 'upAction',
       tap: 'tap',
       trackstart: 'trackStart',
       trackx: 'trackx',
       trackend: 'trackEnd'
+    },
+
+    downAction: function(e) {
+      var rect = this.$.ink.getBoundingClientRect();
+      this.$.ink.downAction({
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2
+      });
+    },
+
+    upAction: function(e) {
+      this.$.ink.upAction();
     },
 
     tap: function() {

--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -120,11 +120,17 @@ To change the toggle bar and toggle button colors separately:
     },
 
     tap: function() {
+      if (this.disabled) {
+        return;
+      }
       this.checked = !this.checked;
       this.fire('change');
     },
 
     trackStart: function(e) {
+      if (this.disabled) {
+        return;
+      }
       this._w = this.$.toggleBar.offsetWidth / 2;
       e.preventTap();
     },

--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -17,40 +17,38 @@ Example:
 
 Styling toggle button:
 
-To change the ink color for checked state:
+To change the toggle color:
 
-    paper-toggle-button::shadow #ink[checked] {
+    paper-toggle-button::shadow .toggle {
+      background-color: #9c27b0;
+    }
+
+To change the ink color:
+    
+    paper-toggle-button::shadow .toggle-ink {
+      color: #009688;
+    }
+
+To change the checked toggle color:
+
+    paper-toggle-button::shadow [checked] .toggle {
+      background-color: #4285f4;
+    }
+
+To change the checked ink color:
+
+    paper-toggle-button::shadow [checked] .toggle-ink {
       color: #4285f4;
     }
-    
-To change the button checked color:
-    
-    paper-toggle-button::shadow #toggleButton[checked] {
-      background-color: #4285f4;
-    }
-    
-To change the bar color for checked state:
 
-    paper-toggle-button::shadow #toggleBar[checked] {
-      background-color: #4285f4;
-    }
-    
-To change the ink color for unchecked state:
+To change the toggle bar and toggle button colors separately:
 
-    paper-toggle-button::shadow #ink {
-      color: #b5b5b5;
-    }
-    
-To change the radio unchecked color:
-    
-    paper-toggle-button::shadow #toggleButton {
-      background-color: #b5b5b5;
+    paper-toggle-button::shadow .toggle-bar {
+      background-color: #5677fc;
     }
 
-To change the bar color for unchecked state:
-
-    paper-toggle-button::shadow #toggleBar {
-      background-color: red;
+    paper-toggle-button::shadow .toggle-button {
+      background-color: #9c27b0;
     }
 
 @group Paper Elements
@@ -59,21 +57,21 @@ To change the bar color for unchecked state:
 -->
 
 <link rel="import" href="../paper-radio-button/paper-radio-button.html">
+<link rel="import" href="../core-a11y-keys/core-a11y-keys.html">
 
-<polymer-element name="paper-toggle-button" attributes="checked" role="button" aria-pressed="false" tabindex="0"
-  on-trackstart="{{trackStart}}" on-trackx="{{trackx}}" on-trackend="{{trackEnd}}">
+<polymer-element name="paper-toggle-button" attributes="checked" role="button" aria-pressed="false" tabindex="0">
 <template>
 
   <link rel="stylesheet" href="paper-toggle-button.css">
 
-  <core-a11y-keys target="{{}}" keys="space" on-keys-pressed="{{toggle}}"></core-a11y-keys>
+  <core-a11y-keys target="{{}}" keys="space" on-keys-pressed="{{tap}}"></core-a11y-keys>
 
-  <div id="toggleContainer">
+  <div id="toggleContainer" checked?="{{checked}}">
   
-    <div id="toggleBar" checked?="{{checked}}"></div>
+    <div id="toggleBar" class="toggle toggle-bar"></div>
 
-    <div id="toggleButton" checked?="{{checked}}">
-      <paper-ripple id="ink" class="circle recenteringTouch" checked?="{{checked}}"></paper-ripple>
+    <div id="toggleButton" class="toggle toggle-button">
+      <paper-ripple id="ink" class="toggle-ink circle recenteringTouch"></paper-ripple>
     </div>
 
   </div>
@@ -105,15 +103,13 @@ To change the bar color for unchecked state:
     checked: false,
     
     eventDelegates: {
-      tap: 'toggle'
+      tap: 'tap',
+      trackstart: 'trackStart',
+      trackx: 'trackx',
+      trackend: 'trackEnd'
     },
 
-    /**
-     * Toggles the state of the the button.
-     *
-     * @method toggle
-     */
-    toggle: function() {
+    tap: function() {
       this.checked = !this.checked;
       this.fire('change');
     },

--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -19,13 +19,13 @@ Styling toggle button:
 
 To change the ink color for checked state:
 
-    paper-toggle-button::shadow paper-radio-button::shadow #ink[checked] {
+    paper-toggle-button::shadow #ink[checked] {
       color: #4285f4;
     }
     
-To change the radio checked color:
+To change the button checked color:
     
-    paper-toggle-button::shadow paper-radio-button::shadow #onRadio {
+    paper-toggle-button::shadow #toggleButton[checked] {
       background-color: #4285f4;
     }
     
@@ -37,14 +37,14 @@ To change the bar color for checked state:
     
 To change the ink color for unchecked state:
 
-    paper-toggle-button::shadow paper-radio-button::shadow #ink {
+    paper-toggle-button::shadow #ink {
       color: #b5b5b5;
     }
     
 To change the radio unchecked color:
     
-    paper-toggle-button::shadow paper-radio-button::shadow #offRadio {
-      border-color: #b5b5b5;
+    paper-toggle-button::shadow #toggleButton {
+      background-color: #b5b5b5;
     }
 
 To change the bar color for unchecked state:
@@ -60,18 +60,22 @@ To change the bar color for unchecked state:
 
 <link rel="import" href="../paper-radio-button/paper-radio-button.html">
 
-<polymer-element name="paper-toggle-button" attributes="checked" role="button" aria-pressed="false" tabindex="0">
+<polymer-element name="paper-toggle-button" attributes="checked" role="button" aria-pressed="false" tabindex="0"
+  on-trackstart="{{trackStart}}" on-trackx="{{trackx}}" on-trackend="{{trackEnd}}">
 <template>
 
   <link rel="stylesheet" href="paper-toggle-button.css">
 
+  <core-a11y-keys target="{{}}" keys="space" on-keys-pressed="{{toggle}}"></core-a11y-keys>
+
   <div id="toggleContainer">
   
     <div id="toggleBar" checked?="{{checked}}"></div>
-  
-    <paper-radio-button id="toggleRadio" toggles checked="{{checked}}" on-change="{{changeAction}}" on-core-change="{{stopPropagation}}"
-        on-trackstart="{{trackStart}}" on-trackx="{{trackx}}" on-trackend="{{trackEnd}}"></paper-radio-button>
-    
+
+    <div id="toggleButton" checked?="{{checked}}">
+      <paper-ripple id="ink" class="circle recenteringTouch" checked?="{{checked}}"></paper-ripple>
+    </div>
+
   </div>
 
 </template>
@@ -99,24 +103,38 @@ To change the bar color for unchecked state:
      * @default false
      */
     checked: false,
+    
+    eventDelegates: {
+      tap: 'toggle'
+    },
+
+    /**
+     * Toggles the state of the the button.
+     *
+     * @method toggle
+     */
+    toggle: function() {
+      this.checked = !this.checked;
+      this.fire('change');
+    },
 
     trackStart: function(e) {
-      this._w = this.$.toggleBar.offsetLeft + this.$.toggleBar.offsetWidth;
+      this._w = this.$.toggleBar.offsetWidth / 2;
       e.preventTap();
     },
 
     trackx: function(e) {
       this._x = Math.min(this._w, 
           Math.max(0, this.checked ? this._w + e.dx : e.dx));
-      this.$.toggleRadio.classList.add('dragging');
-      var s =  this.$.toggleRadio.style;
+      this.$.toggleButton.classList.add('dragging');
+      var s =  this.$.toggleButton.style;
       s.webkitTransform = s.transform = 'translate3d(' + this._x + 'px,0,0)';
     },
 
     trackEnd: function() {
-      var s =  this.$.toggleRadio.style;
+      var s =  this.$.toggleButton.style;
       s.transform = s.webkitTransform = '';
-      this.$.toggleRadio.classList.remove('dragging');
+      this.$.toggleButton.classList.remove('dragging');
       var old = this.checked;
       this.checked = Math.abs(this._x) > this._w / 2;
       if (this.checked !== old) {
@@ -127,15 +145,6 @@ To change the bar color for unchecked state:
     checkedChanged: function() {
       this.setAttribute('aria-pressed', Boolean(this.checked));
       this.fire('core-change');
-    },
-    
-    changeAction: function(e) {
-      e.stopPropagation();
-      this.fire('change');
-    },
-    
-    stopPropagation: function(e) {
-      e.stopPropagation();
     }
 
   });


### PR DESCRIPTION
The "new" toggle button with a thicker track. It hasn't been published yet, but I'd like to get some feedback now. Specifically, @azakus how does <core-a11y-keys> work (can't get this or <paper-radio-button> to toggle with the spacebar)?

With <paper-radio-button> removed from this element, <paper-radio-button> can now be changed so that it matches the spec (with the spacing between the border and center circle; see https://www.google.com/design/spec/components/switches.html#switches-radio-button)

Assigning to @frankiefu since he seems to have put a lot of work to this element.
